### PR TITLE
add xml.fileAssociations configuration item

### DIFF
--- a/xml/src/browser/xml-preferences.ts
+++ b/xml/src/browser/xml-preferences.ts
@@ -40,6 +40,24 @@ export const XMLConfigSchema: PreferenceSchema = {
             "default": true,
             "description": "Insert space before end of self closing tag. \nExample:\n  <tag/> -> <tag />"
         },
+        "xml.fileAssociations": {
+            "type": "array",
+            "default": [],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "systemId": {
+                        "type": "string",
+                        "description": "The path or URL to the XML schema (XSD or DTD)"
+                    },
+                    "pattern": {
+                        "type": "string",
+                        "description": "File glob pattern. Example: **/*.Format.ps1xml\n\nMore information on the glob syntax: https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob",
+                    }
+                }
+            },
+            "description": "Allows XML schemas to be associated to file name patterns.\n\nExample:\n[{\n  \"systemId\": \"path/to/file.xsd\",\n  \"pattern\": \"file1.xml\"\n},\n{\n  \"systemId\": \"http://www.w3.org/2001/XMLSchema.xsd\",\n  \"pattern\": \"**/*.xsd\"\n}]",
+        },
         "xml.logs.client": {
             "type": "boolean",
             "default": false,


### PR DESCRIPTION
This patch will add xml.fileAssociations configuration item to the extension.

`xml.fileAssociations` will enable us to associate files with specific extension to the XSD. In my use case, I use this to edit ROS configuration files:
```
   "files.associations": {
        "*.launch": "xml",
        "*.urdf.xacro": "xml",
        "*.urdf": "xml",
        "model.config": "xml",
        "*.sdf": "xml"
    },
    "xml.fileAssociations": [
        {
            "systemId": "http://download.ros.org/schema/package_format2.xsd",
            "pattern": "package.xml"
        },
        {
            "systemId": "https://gist.githubusercontent.com/nalt/dfa2abc9d2e3ae4feb82ca5608090387/raw/roslaunch.xsd",
            "pattern": "**/*.launch"
        },
        {
            "systemId": "https://raw.githubusercontent.com/ros/urdfdom/master/xsd/urdf.xsd",
            "pattern": "**/*.urdf.xacro"
        },
        {
            "systemId": "https://raw.githubusercontent.com/ros/urdfdom/master/xsd/urdf.xsd",
            "pattern": "**/*.urdf"
        },
        {
            "systemId": "http://sdformat.org/schemas/root.xsd",
            "pattern": "**/*.sdf"
        }
    ]
```